### PR TITLE
Features/azure data suggest groups

### DIFF
--- a/app/Http/Controllers/MSGraphController.php
+++ b/app/Http/Controllers/MSGraphController.php
@@ -165,7 +165,8 @@ class MSGraphController extends Controller
                     $user->save();
                 }
 
-                if (!$user->hasRole($group)) {
+                // Set the group for the user, but don't override an Administrator!
+                if (!$user->hasRole($group) && !$user->hasRole('Administrators')) {
                     $user->syncRoles([$group]);
                     $user->touch();
                 }

--- a/app/Http/Controllers/MSGraphController.php
+++ b/app/Http/Controllers/MSGraphController.php
@@ -66,8 +66,10 @@ class MSGraphController extends Controller
         ]);
         $content = json_decode(curl_exec($curl), true);
         curl_close($curl);
-        // TODO: Should handle errors in this
-
+        if (isset($content['error'])) {
+            abort(500, $content['error_description']);
+        }
+        
         $token = MSGraphToken::create([
             'access_token' => $content['access_token'],
             'expires' => (time() + $content['expires_in']),

--- a/app/Http/Controllers/SecurityController.php
+++ b/app/Http/Controllers/SecurityController.php
@@ -116,7 +116,8 @@ class SecurityController extends Controller
         $mappings = [];
 
         foreach ($maps as $map) {
-            $mappings[$map->role_id] = $map->azure_group_id;
+            $mappings[$map->role_id]['azure_group_id'] = $map->azure_group_id;
+            $mappings[$map->role_id]['azure_display_name'] = $map->azure_display_name;
         }
 
         return response()->json([
@@ -131,16 +132,19 @@ class SecurityController extends Controller
     {
         $group = $request->input('group_id');
         $azGroup = $request->input('azure_group_id');
+        $azDisplay = $request->input('azure_display_name');
 
         $current = GroupToAzureGroup::where('role_id', $group)->first();
 
         if ($current && $current->azure_group_id <> $azGroup) {
             $current->azure_group_id = $azGroup;
+            $current->azure_display_name = $azDisplay;
             $current->save();
         } elseif (!$current) {
             GroupToAzureGroup::create([
                 'role_id' => $group,
-                'azure_group_id' => $azGroup
+                'azure_group_id' => $azGroup,
+                'azure_display_name' => $azDisplay,
             ]);
         }
 

--- a/app/Models/GroupToAzureGroup.php
+++ b/app/Models/GroupToAzureGroup.php
@@ -12,5 +12,6 @@ class GroupToAzureGroup extends Model
     protected $fillable = [
         'role_id',
         'azure_group_id',
+        'azure_display_name',
     ];
 }

--- a/database/migrations/2022_02_21_134958_add_azure_display_name_to_group_to_azure_groups_table.php
+++ b/database/migrations/2022_02_21_134958_add_azure_display_name_to_group_to_azure_groups_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAzureDisplayNameToGroupToAzureGroupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('group_to_azure_groups', function (Blueprint $table) {
+            $table->string('azure_display_name')->after('azure_group_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('group_to_azure_groups', function (Blueprint $table) {
+            $table->dropColumn('azure_display_name');
+        });
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17199,9 +17199,9 @@
             }
         },
         "webapps-react": {
-            "version": "1.8.17",
-            "resolved": "https://registry.npmjs.org/webapps-react/-/webapps-react-1.8.17.tgz",
-            "integrity": "sha512-I9GdDFkMhGbR5/xlmadHStIWwJf5heG+Os/ouJjK9ycun4lHusRhLC5hAASDqAzuxhMu6PpxUTnqgUqvvVXCsg==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/webapps-react/-/webapps-react-1.9.0.tgz",
+            "integrity": "sha512-eXPBW+InXlEiOKr3mn9kQnOYlepT6+tR+GNYDtRT2S29lNsGmRYnxQ3W3QXe979YPHfoRh+64cgHpJYin9AkRA==",
             "dev": true
         },
         "webpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17199,9 +17199,9 @@
             }
         },
         "webapps-react": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/webapps-react/-/webapps-react-1.9.0.tgz",
-            "integrity": "sha512-eXPBW+InXlEiOKr3mn9kQnOYlepT6+tR+GNYDtRT2S29lNsGmRYnxQ3W3QXe979YPHfoRh+64cgHpJYin9AkRA==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/webapps-react/-/webapps-react-1.9.1.tgz",
+            "integrity": "sha512-5kLWTqqLv9keF9RwHKLqh6IhYfAK3+hEIz+FpaQT8Sj6JZSxfSw+0hbFPf9H1HuS2B4d0x7cxH/VOt73I4UVdw==",
             "dev": true
         },
         "webpack": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "tiny-invariant": "^1.2.0",
         "url": "^0.11.0",
         "values.js": "^2.0.0",
-        "webapps-react": "^1.9.0",
+        "webapps-react": "^1.9.1",
         "whatwg-fetch": "^3.6.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "tiny-invariant": "^1.2.0",
         "url": "^0.11.0",
         "values.js": "^2.0.0",
-        "webapps-react": "^1.8.17",
+        "webapps-react": "^1.9.0",
         "whatwg-fetch": "^3.6.2"
     }
 }

--- a/resources/js/components/Routes/Settings/GroupSearch/GroupSearch.js
+++ b/resources/js/components/Routes/Settings/GroupSearch/GroupSearch.js
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { Input } from 'webapps-react';
+
+const GroupSearch = ({ id, groupData, setData, accessToken, saveChange, ...props }) => {
+    const [controllers, setControllers] = useState([]);
+    const [active, setActive] = useState(0);
+    const [showResults, setShowResults] = useState(false);
+
+    const change = e => {
+        // Abort any running requests
+        controllers.map(function (controller, i) {
+            controller?.abort();
+            delete controllers[i];
+        });
+        let signal = new AbortController();
+        setControllers([...controllers, signal]);
+
+        let id = e.target.id;
+        let value = e.target.value;
+
+        if (groupData[id] === undefined) {
+            groupData[id] = {};
+        }
+        groupData[id].value = value;
+
+        let headers = new Headers();
+        let bearer = `Bearer ${accessToken}`;
+        headers.append('Authorization', bearer);
+        let options = {
+            method: "GET",
+            headers: headers,
+            signal: signal.signal
+        };
+        let graphEndpoint = `https://graph.microsoft.com/v1.0/groups?$filter=startswith(displayName, '${value}')&$select=id,displayName`;
+
+        fetch(graphEndpoint, options)
+            .then(response => response.json())
+            .then(data => {
+                groupData[id].data = data.value
+
+                setData([...groupData]);
+                setActive(0);
+                setShowResults(true);
+            })
+            .catch(error => {
+                if (!error.status?.isAbort) {
+                    // TODO: Handle Errors
+                    console.log(error)
+                }
+            });
+    }
+
+    const onClick = e => {
+        e.stopPropagation();
+
+        groupData[id].selected = groupData[id].data[e.currentTarget.dataset.key];
+        groupData[id].value = groupData[id].data[e.currentTarget.dataset.key].displayName;
+        groupData[id].data = [];
+
+        setActive(0);
+        setShowResults(false);
+        setData([...groupData]);
+        saveChange(id);
+    }
+
+    const onKeyDown = e => {
+        if (e.keyCode === 13) {
+            groupData[id].selected = groupData[id].data[active];
+            groupData[id].value = groupData[id].data[active].displayName;
+            setData([...groupData]);
+            setShowResults(false);
+            setActive(0);
+            saveChange(id);
+        } else if (e.keyCode === 38) {
+            if (active === 0) {
+                return;
+            }
+            setActive(active - 1);
+        } else if (e.keyCode === 40) {
+            if (active + 1 === groupData[id].data.length) {
+                return;
+            }
+            setActive(active + 1);
+        }
+    }
+
+    let DataListComponent;
+
+    if (showResults && groupData[id]?.value) {
+        if (groupData[id].data?.length) {
+            let count = 1;
+            DataListComponent = (
+                <ul className="z-50 absolute inset-x-0 bg-white dark:bg-gray-700 rounded-b border border-gray-200 dark:border-gray-600 text-gray-900 text-sm font-medium dark:text-white cursor-pointer">
+                    {
+                        groupData[id].data.map((data, index) => {
+                            if (count <= 5) {
+                                let className = "flex flex-row gap-x-2 px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-900";
+
+                                if (index === active) {
+                                    className = "flex flex-row gap-x-2 px-4 py-2 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-900";
+                                }
+
+                                count = count + 1;
+
+                                return <li className={className} key={data.id} data-key={index} onClick={onClick}>{data.displayName}</li>
+                            }
+                        })
+                    }
+                </ul>
+            )
+        } else {
+            DataListComponent = (
+                <ul className="z-50 absolute inset-x-0 bg-white dark:bg-gray-700 rounded-b border border-gray-200 dark:border-gray-600 text-gray-900 text-sm font-medium dark:text-white cursor-pointer">
+                    <li className="px-4 py-2 text-center"><em>No matching groups found!</em></li>
+                </ul>
+            );
+        }
+    }
+
+    return (
+        <div className="relative w-full">
+            <Input type="text" id={id} value={groupData[id]?.value || ''} onChange={change} onKeyDown={onKeyDown} state={groupData[id]?.state} {...props} />
+            {DataListComponent}
+        </div>
+    );
+}
+
+export default GroupSearch;

--- a/resources/js/components/Routes/Settings/GroupSearch/GroupSearch.js
+++ b/resources/js/components/Routes/Settings/GroupSearch/GroupSearch.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { Input } from 'webapps-react';
 
 const GroupSearch = ({ id, groupData, setData, accessToken, saveChange, ...props }) => {

--- a/tests/Feature/SecurityRoutesTest.php
+++ b/tests/Feature/SecurityRoutesTest.php
@@ -605,7 +605,7 @@ class SecurityRoutesTest extends TestCase
         $response->assertJsonFragment([
             'mappings' => [
                 $role_id => [
-                    'azure_group_id' => "PHPUnit_Test_Group-ID",
+                    'azure_group_id' => "PHPUnit_Test_Group_ID",
                     'azure_display_name' => "PHPUnit_Test_Group",
                 ]
             ]

--- a/tests/Feature/SecurityRoutesTest.php
+++ b/tests/Feature/SecurityRoutesTest.php
@@ -595,7 +595,8 @@ class SecurityRoutesTest extends TestCase
 
         GroupToAzureGroup::create([
             'role_id' => $role_id,
-            'azure_group_id' => 'PHPUnit_Test_Group'
+            'azure_group_id' => 'PHPUnit_Test_Group_ID',
+            'azure_display_name' => 'PHPUnit_Test_Group',
         ]);
 
         $response = $this->getJson('/api/group/mappings');
@@ -603,7 +604,10 @@ class SecurityRoutesTest extends TestCase
         $response->assertSuccessful();
         $response->assertJsonFragment([
             'mappings' => [
-                $role_id => "PHPUnit_Test_Group"
+                $role_id => [
+                    'azure_group_id' => "PHPUnit_Test_Group-ID",
+                    'azure_display_name' => "PHPUnit_Test_Group",
+                ]
             ]
         ]);
     }
@@ -621,12 +625,14 @@ class SecurityRoutesTest extends TestCase
 
         GroupToAzureGroup::create([
             'role_id' => $role_id,
-            'azure_group_id' => 'PHPUnit_Test_Group'
+            'azure_group_id' => 'PHPUnit_Test_Group_ID',
+            'azure_display_name' => 'PHPUnit_Test_Group',
         ]);
 
         $response = $this->postJson('/api/group/mapping', [
             'group_id' => $role_id,
-            'azure_group_id' => 'PHPUnit_Second_Test_Group'
+            'azure_group_id' => "PHPUnit_Second_Test_Group-ID",
+            'azure_display_name' => "PHPUnit_Second_Test_Group",
         ]);
 
         $response->assertSuccessful();
@@ -648,7 +654,8 @@ class SecurityRoutesTest extends TestCase
 
         $response = $this->postJson('/api/group/mapping', [
             'group_id' => $role_id,
-            'azure_group_id' => 'PHPUnit_Second_Test_Group'
+            'azure_group_id' => "PHPUnit_Second_Test_Group-ID",
+            'azure_display_name' => "PHPUnit_Second_Test_Group",
         ]);
 
         $response->assertSuccessful();

--- a/tests/Javascript/Settings/Azure/Azure_Configured.test.js
+++ b/tests/Javascript/Settings/Azure/Azure_Configured.test.js
@@ -29,9 +29,8 @@ describe('Azure Component - Configured', () => {
         expect(screen.getByText(/azure app registration information/i)).toBeDefined();
         expect(screen.getByText(/map azure groups to webapps groups/i)).toBeDefined();
         expect(screen.getByText(/azure synchronisation status/i)).toBeDefined();
-        expect(screen.getByRole('textbox', { name: /administrators/i })).toBeDefined();
 
-        await waitFor(async () => expect(screen.getByRole('textbox', { name: /administrators/i }).children).toHaveLength(3));
+        await waitFor(async () => expect(screen.getByRole('textbox', { name: /administrators/i })).toBeDefined());
     });
 
     test('Can Enable Azure Authentication', async () => {

--- a/tests/Javascript/Settings/Azure/Azure_Configured.test.js
+++ b/tests/Javascript/Settings/Azure/Azure_Configured.test.js
@@ -29,9 +29,9 @@ describe('Azure Component - Configured', () => {
         expect(screen.getByText(/azure app registration information/i)).toBeDefined();
         expect(screen.getByText(/map azure groups to webapps groups/i)).toBeDefined();
         expect(screen.getByText(/azure synchronisation status/i)).toBeDefined();
-        expect(screen.getByRole('combobox', { name: /administrators/i })).toBeDefined();
+        expect(screen.getByRole('textbox', { name: /administrators/i })).toBeDefined();
 
-        await waitFor(async () => expect(screen.getByRole('combobox', { name: /administrators/i }).children).toHaveLength(3));
+        await waitFor(async () => expect(screen.getByRole('textbox', { name: /administrators/i }).children).toHaveLength(3));
     });
 
     test('Can Enable Azure Authentication', async () => {
@@ -72,19 +72,19 @@ describe('Azure Component - Configured', () => {
 
     // FIXME: This is not correctly testing a result
     // test('Can Add A Group Mapping', async () => {
-    //     expect(screen.getByRole('combobox', { name: /administrators/i })).toBeDefined();
+    //     expect(screen.getByRole('textbox', { name: /administrators/i })).toBeDefined();
 
     //     await waitFor(async () => {
-    //         expect(screen.getByRole('combobox', { name: /administrators/i }).children).toHaveLength(3);
+    //         expect(screen.getByRole('textbox', { name: /administrators/i }).children).toHaveLength(3);
     //     });
 
-    //     expect(screen.getByRole('combobox', { name: /administrators/i }).children).toHaveLength(3);
+    //     expect(screen.getByRole('textbox', { name: /administrators/i }).children).toHaveLength(3);
 
     //     await act(async () => {
-    //         fireEvent.change(screen.getByRole('combobox', { name: /administrators/i }), { target: { value: '001' } });
-    //         await screen.getByRole('combobox', { name: /administrators/i }).value === '001';
+    //         fireEvent.change(screen.getByRole('textbox', { name: /administrators/i }), { target: { value: '001' } });
+    //         await screen.getByRole('textbox', { name: /administrators/i }).value === '001';
     //     });
-    //     await waitFor(() => expect(screen.getByRole('combobox', { name: /administrators/i }).children).toHaveLength(3));
+    //     await waitFor(() => expect(screen.getByRole('textbox', { name: /administrators/i }).children).toHaveLength(3));
     // });
 
     test('Can Request A Manual Azure Sync', async () => {

--- a/tests/Javascript/Settings/Azure/Azure_PartiallyConfigured.test.js
+++ b/tests/Javascript/Settings/Azure/Azure_PartiallyConfigured.test.js
@@ -46,9 +46,7 @@ describe('Azure Component - Partially Configured', () => {
         await waitFor(async () => {
             expect(screen.getByText(/map azure groups to webapps groups/i)).toBeDefined();
             expect(screen.getByText(/azure synchronisation status/i)).toBeDefined();
-            expect(screen.getByRole('combobox', { name: /administrators/i }).children).toHaveLength(3);
+            expect(screen.getByRole('textbox', { name: /administrators/i })).toBeDefined();
         });
-
-        expect(screen.getByRole('combobox', { name: /administrators/i }).children).toHaveLength(3);
     });
 });


### PR DESCRIPTION
This PR:
- Handles CURL error when acquiring an MS Graph API Access Token
- Azure Group Mappings are now an Input Search, rather than a Select (Graph API limits to 100 groups, this now searches as the user does)
- Prevents a user from being removed from the Administrators Group if an Azure Group tries to move them into a different group